### PR TITLE
add 'in-game music' setting which enables or disables music playing

### DIFF
--- a/mods/PLAYER/mcl_music/init.lua
+++ b/mods/PLAYER/mcl_music/init.lua
@@ -84,7 +84,13 @@ local function play()
 				fade      = 0.0,
 				pitch     = 1.0,
 			}
-			handle = minetest.sound_play(spec, parameters, false)
+
+			-- load the music setting and only play if set to true
+			local in_game_music = minetest.settings:get_bool("in_game_music", true)
+			if in_game_music then
+				handle = minetest.sound_play(spec, parameters, false)
+			end
+
 			listeners[player_name] = {
 				spec       = spec,
 				parameters = parameters,

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -91,6 +91,8 @@ mobs_disable_blood (Disable mob damage particles) bool false
 [Audio]
 # Enable flame sound.
 flame_sound (Flame sound) bool true
+# Enable in-game music
+in_game_music (In-game music) bool true
 
 [Graphics]
 # How many vertical animation frames the fire texture (fire_basic_flame_animated.png) has.


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/101313255/178734897-acd46b94-6dbb-4906-8611-bbf7e438d125.png)

Tested for the initial music that plays on a new world spawn but not in every other case. This doesn't affect the menu music though, I can't seem to find how that gets started. Must be in Minetest code. 

Edit: I should clarify, the setting is true by default. Nothing changes in the game as a result of this change except that it can now be disabled if desired.